### PR TITLE
Add assembly marker classes for MediatR registration

### DIFF
--- a/DPTS.Applications/Buyers/BuyerAssemblyMarker.cs
+++ b/DPTS.Applications/Buyers/BuyerAssemblyMarker.cs
@@ -1,0 +1,6 @@
+﻿namespace DPTS.Applications.Buyers
+{
+    public sealed class BuyerAssemblyMarker
+    {
+    }
+}

--- a/DPTS.Applications/Config.cs
+++ b/DPTS.Applications/Config.cs
@@ -1,4 +1,7 @@
-﻿using DPTS.Applications.NoDistinctionOfRoles.auths.Queries;
+﻿using DPTS.Applications.Buyers;
+using DPTS.Applications.NoDistinctionOfRoles;
+using DPTS.Applications.NoDistinctionOfRoles.auths.Queries;
+using DPTS.Applications.Sellers;
 using DPTS.Applications.Sellers.overviews.Queries;
 using DPTS.Infrastructures.Data;
 using DPTS.Infrastructures.Repository.Implements;
@@ -29,8 +32,9 @@ namespace DPTS.Applications
             services.AddMediatR(cfg =>
             {
                 cfg.RegisterServicesFromAssemblies(
-                    typeof(GetSellerOverviewQuery).Assembly,   
-                    typeof(LoginQuery).Assembly                 
+                    typeof(BuyerAssemblyMarker).Assembly,   
+                    typeof(SellersAssemblyMarker).Assembly,      
+                    typeof(NoDistinctionOfRoleAssemblyMarker).Assembly                 
                 );
             });
         }

--- a/DPTS.Applications/NoDistinctionOfRoles/NoDistinctionOfRoleAssemblyMarker.cs
+++ b/DPTS.Applications/NoDistinctionOfRoles/NoDistinctionOfRoleAssemblyMarker.cs
@@ -1,0 +1,6 @@
+﻿namespace DPTS.Applications.NoDistinctionOfRoles
+{
+    public sealed class NoDistinctionOfRoleAssemblyMarker
+    {
+    }
+}

--- a/DPTS.Applications/Sellers/SellersAssemblyMarker.cs
+++ b/DPTS.Applications/Sellers/SellersAssemblyMarker.cs
@@ -1,0 +1,6 @@
+﻿namespace DPTS.Applications.Sellers
+{
+    public sealed class SellersAssemblyMarker
+    {
+    }
+}


### PR DESCRIPTION
Introduced BuyerAssemblyMarker, SellersAssemblyMarker, and NoDistinctionOfRoleAssemblyMarker classes to facilitate explicit assembly registration with MediatR in the Config class. Updated Config.cs to use these marker classes for clearer and more maintainable service registration.